### PR TITLE
Added support for using template files instead of strings.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,8 @@ in ``settings.py``. Here's the default settings:
         'DEFAULT': {
             'persistent': True,  # stays until dismissed
             'send_as_email': False,  # send as email
+            'headline_template_name': 'headline.txt',  # Django template file for headline
+            'body_template_name': 'body.txt',  # Django template file for body
             'headline_template': '{{headline}}',  # Django template for headline
             'body_template': '{{body}}',  # Django template for body
             'email_field': 'email'  # Assume field named 'email' is user's email
@@ -56,8 +58,10 @@ notification is another key in the ``NOTIFICATIONS`` dictionary.
 
 - ``persistent``: Whether or not notifications are marked as inactive once emailed to a user.
 - ``send_as_email``: Whether or not to send this kind of notification as an email.
-- ``headline_template``: A Django template string that'll be rendered with a context dictionary for the headline.
-- ``body_template``: A Django template string that'll be rendered with a context dictionary for the body.
+- ``headline_template_name``: A Django template file that'll be rendered with a context dictionary for the headline.
+- ``body_template_name``: A Django template file that'll be rendered with a context dictionary for the body.
+- ``headline_template``: A Django template string that'll be rendered with a context dictionary for the headline. Only used if ``headline_template_name`` is not provided.
+- ``body_template``: A Django template string that'll be rendered with a context dictionary for the body. Only used if ``body_template_name`` is not provided.
 - ``email_field``: The field on your user model that holds the user's email address.
 
 .. _methods:

--- a/heythere/models.py
+++ b/heythere/models.py
@@ -7,6 +7,7 @@ from django.core.mail import send_mail, send_mass_mail
 from django.db import models
 from django.utils.functional import lazy
 from django.utils.timezone import now
+from django.template import loader
 
 from .settings import get_notifications
 from .utils import render
@@ -120,14 +121,28 @@ class Notification(models.Model):
             headline_dict = self.headline_dict
             body_dict = self.body_dict
 
-        self.headline = render(
-            self.notification_dict['headline_template'],
-            headline_dict
-        )
-        self.body = render(
-            self.notification_dict['body_template'],
-            body_dict
-        )
+        if 'headline_template_name' in self.notification_dict:
+            self.headline = loader.render_to_string(
+                self.notification_dict['headline_template_name'],
+                headline_dict
+            ).strip()
+        else:
+            self.headline = render(
+                self.notification_dict['headline_template'],
+                headline_dict
+            )
+
+        if 'body_template_name' in self.notification_dict:
+            self.body = loader.render_to_string(
+                self.notification_dict['body_template_name'],
+                body_dict
+            ).strip()
+        else:
+            self.body = render(
+                self.notification_dict['body_template'],
+                body_dict
+            )
+
         if not self.persistent and self.sent_at:
             self.active = False
         super(Notification, self).save(*args, **kwargs)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -89,5 +89,12 @@ NOTIFICATIONS = {
         'send_as_email': True,
         'headline_template': 'My headline: {{headline}}',
         'body_template': 'My body: {{body}}',
+    },
+    'TEMPLATE_FILES': {
+        'persistent': True,
+        'send_onsite': False,
+        'send_as_email': True,
+        'headline_template_name': 'headline.txt',
+        'body_template_name': 'body.txt',
     }
 }

--- a/tests/templates/body.txt
+++ b/tests/templates/body.txt
@@ -1,0 +1,1 @@
+My body from file: {{body}}

--- a/tests/templates/headline.txt
+++ b/tests/templates/headline.txt
@@ -1,0 +1,1 @@
+My headline from file: {{headline}}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -107,3 +107,8 @@ class TestNotificationModel(test.TestCase):
                 'notification_type')[0].get_choices())
         notification = self._create_notification('CUSTOM_USER')
         self.assertIn('My body:', notification.body)
+
+    def test_using_template_files(self):
+        notification = self._create_notification('TEMPLATE_FILES')
+        self.assertIn('My headline from file:', notification.headline)
+        self.assertIn('My body from file:', notification.body)


### PR DESCRIPTION
Defining all notifications inside `settings.py` is not so pretty when you have 10+ notifications that use templatetags or simply have long text.

Added two options: `headline_template_name` and `body_template_name`, that if set, are used instead of the other template string options to render a template file for the notification headline and body.

Included documentation updates and test case.
